### PR TITLE
Implemented Http endpoint example

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="mobile"
         android:name="${applicationName}"

--- a/mobile/lib/http/test_list.dart
+++ b/mobile/lib/http/test_list.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class TestList {
+  final List testList;
+
+  const TestList({
+    required this.testList,
+  });
+
+  factory TestList.fromJson(Map<String, dynamic> json) {
+    return TestList(
+      testList: json['data'],
+    );
+  }
+}
+
+Future<TestList> fetchTestList() async {
+  final response = await http.get(Uri.parse('http://127.0.0.1:3000/api/v1/tests'));
+  if (response.statusCode == 200) {
+    return TestList.fromJson(jsonDecode(response.body));
+  } else {
+    throw Exception('FAIL');
+  }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mobile/response_schema/test_list.dart';
 import 'package:provider/provider.dart';
 
 void main() {
@@ -66,6 +67,7 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
   late TabController _tabController;
+  late Future<TestList> futureTestList;
   void _incrementCounter() {
     setState(() {
       _counter++;
@@ -82,6 +84,7 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
   void initState() {
     super.initState();
     _tabController = TabController(initialIndex: 1, length: defaultTabs.length, vsync: this);
+    futureTestList = fetchTestList();
   }
 
   @override
@@ -138,7 +141,21 @@ class _HomePageState extends State<HomePage> with SingleTickerProviderStateMixin
               child: Text("Left Pane"),
           ),
           Center(
-              child: CounterCard(counter: _counter, reset: _resetCounter),
+              child: CounterCard(
+                  counter: _counter,
+                  reset: _resetCounter,
+                  testText: FutureBuilder<TestList>(
+                    future: futureTestList,
+                    builder: (context, snapshot) {
+                      if (snapshot.hasData) {
+                        return Text(snapshot.data!.testList.toString());
+                      } else if (snapshot.hasError) {
+                        return Text('${snapshot.error}');
+                      }
+                      return const CircularProgressIndicator();
+                    }
+                  ),
+              ),
           ),
           const Center(
               child: Text('RIGHT PANE!!'),
@@ -159,9 +176,11 @@ class CounterCard extends StatelessWidget {
     super.key,
     required this.counter,
     required this.reset,
+    required this.testText,
   });
   final int counter;
   final void Function() reset;
+  final Widget testText;
 
   @override
   Widget build(BuildContext context) {
@@ -176,7 +195,8 @@ class CounterCard extends StatelessWidget {
             '$counter',
             style: Theme.of(context).textTheme.headlineMedium,
           ),
-          ElevatedButton(onPressed: reset, child: const Icon(Icons.refresh))
+          ElevatedButton(onPressed: reset, child: const Icon(Icons.refresh)),
+          testText,
         ],
       ),
     );

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -75,6 +75,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "4c3f04bfb64d3efd508d06b41b825542f08122d30bda4933fb95c069d22a4fa3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   js:
     dependency: transitive
     description:
@@ -192,6 +208,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.2"
   vector_math:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  http: ^1.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds a connection to the `test` endpoint. It fetches the list of tests async and shows them on the page. Invocation in the Widget's `initState` means that it is only called once and the response is cached.

![image](https://github.com/sllewely/recommendations/assets/11083848/c91f5e0d-6c9b-4043-acc0-e7a0836f7291)
