### PR TITLE
csrf not applicable to apis, graphql callable on render

### DIFF
--- a/backend/app/controllers/graphql_controller.rb
+++ b/backend/app/controllers/graphql_controller.rb
@@ -2,7 +2,7 @@ class GraphqlController < ApplicationController
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,
   # but you'll have to authenticate your user separately
-  # protect_from_forgery with: :null_session
+  protect_from_forgery with: :null_session
 
   def execute
     variables = prepare_variables(params[:variables])


### PR DESCRIPTION
# Feature

![image](https://github.com/sllewely/recommendations/assets/8452651/ae6f892a-dee4-4245-8c58-17dfc42a16ed)


https://stackoverflow.com/questions/35181340/rails-cant-verify-csrf-token-authenticity-when-making-a-post-request