### PR TITLE
get all UserMedium with access to current user

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -148,3 +148,17 @@ bundle install
 ```
 rails db:create
 ```
+
+
+## Testing the Graphql API
+
+[API.md](https://github.com/sllewely/recommendations/blob/main/backend/API.md)
+
+- Start the server ```rails s```
+- Get oauth token with [POST /oauth/token](https://github.com/sllewely/recommendations/blob/main/backend/API.md)
+- Visit [http://localhost:3000/graphiql](http://localhost:3000/graphiql)
+- Provide Auth in headers like: https://github.com/sllewely/recommendations/pull/27
+
+
+
+

--- a/backend/app/graphql/types/query_type.rb
+++ b/backend/app/graphql/types/query_type.rb
@@ -26,7 +26,8 @@ module Types
           null: false,
           description: "Return a list of user media"
     def user_media
-      UserMedium.all
+      current_user = context[:current_user]
+      UserMedium.with_access(current_user)
     end
 
     field :media,

--- a/backend/app/models/user_medium.rb
+++ b/backend/app/models/user_medium.rb
@@ -3,9 +3,6 @@ class UserMedium < ApplicationRecord
   belongs_to :medium
 
   def self.with_access(current_user)
-    debugger
     UserMedium.where(user_id: current_user.id)
   end
-
-
 end

--- a/backend/app/models/user_medium.rb
+++ b/backend/app/models/user_medium.rb
@@ -2,5 +2,10 @@ class UserMedium < ApplicationRecord
   belongs_to :user
   belongs_to :medium
 
+  def self.with_access(current_user)
+    debugger
+    UserMedium.where(user_id: current_user.id)
+  end
+
 
 end


### PR DESCRIPTION
# Feature

When I request UserMedia, but I have none, the results are none.  Scoped to the current user

<img width="1017" alt="image" src="https://github.com/sllewely/recommendations/assets/8452651/0cf2c748-e30a-48d8-af2e-c6bcc113ecd4">

When I request after creating a media for Ziggy, I can see it

<img width="1035" alt="image" src="https://github.com/sllewely/recommendations/assets/8452651/8df7465f-4601-4905-9c67-52bef13c83a1">

(creating:)
<img width="1016" alt="image" src="https://github.com/sllewely/recommendations/assets/8452651/833c658b-20b4-483b-8fb4-881214def579">
